### PR TITLE
Make per-object permissions optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
+  - PERMISSIONS=true
+  - PERMISSIONS=false
 
 before_install:
   - pip install --upgrade pytest
@@ -15,7 +17,8 @@ before_install:
 install:
   - pip install -q Django==$DJANGO
   - pip install -e .
-  - pip install -e '.[permissions]'
+  - if [[ "$PERMISSIONS" == "true" ]]; then pip install -e '.[permissions]'; else echo "[SKIPPED] install permissions"; fi
+  # - pip install -e '.[permissions]'
   - pip install -e '.[test]'
   - pip install codecov
   - cp ci/testsettings.py testsettings.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
 install:
   - pip install -q Django==$DJANGO
   - pip install -e .
+  - pip install -e '.[permissions]'
   - pip install -e '.[test]'
   - pip install codecov
   - cp ci/testsettings.py testsettings.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ python:
   - "3.5"
 
 env:
-  - DJANGO=1.8
-  - DJANGO=1.9
-  - DJANGO=1.10
-  - PERMISSIONS=true
-  - PERMISSIONS=false
+  - DJANGO=1.8 PERMISSIONS=true
+  - DJANGO=1.8 PERMISSIONS=false
+  - DJANGO=1.9 PERMISSIONS=true
+  - DJANGO=1.10 PERMISSIONS=true
+  - DJANGO=1.10 PERMISSIONS=false
 
 before_install:
   - pip install --upgrade pytest

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,6 @@ required components are enabled::
       'django.contrib.contenttypes',
       'django.contrib.sessions',
       'django.contrib.sites',
-      'guardian',
       'annotator_store',
         ...
     )
@@ -78,10 +77,18 @@ Run migrations to create annotation database tables::
 
     python manage.py migrate
 
+.. Note::
+
+  If you want per-object permissions on individual annotations (rather than
+  the standard django type-based permissions), you must also install
+  `django-guardian` and include `guardian` in your
+  **INSTALLED_APPS**.  Per-object permissions must be turned on in Django
+  settings by setting **ANNOTATION_OBJECT_PERMISSIONS** to True.
+
 Custom Annotation Model
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-This module is designed to allow the use of a custom annotation model, in order
+This module is designed to allow the use of a custom Annotation model, in order
 to add functionality or relationships to other models within an application.
 To take advantage of this feature, you should extend the abstract model
 `annotator_store.models.BaseAnnotation` and configure your model in
@@ -89,6 +96,9 @@ Django setings, e.g.::
 
     ANNOTATOR_ANNOTATION_MODEL = 'myapp.LocalAnnotation'
 
+If you want per-object permissions on your annotation model, you should
+extend `annotator_store.models.AnnotationWithPermissions` rather than
+the base annotation class.
 
 Development instructions
 ------------------------

--- a/annotator_store/admin.py
+++ b/annotator_store/admin.py
@@ -2,7 +2,11 @@ from django import forms
 from django.contrib import admin
 from django.contrib.auth.models import User, Group
 
-from .models import get_annotation_model, AnnotationGroup
+from .models import get_annotation_model, ANNOTATION_OBJECT_PERMISSIONS
+
+if ANNOTATION_OBJECT_PERMISSIONS:
+    # annotation group is only defined when permissions are enabled
+    from .models import AnnotationGroup
 
 
 Annotation = get_annotation_model()
@@ -26,57 +30,59 @@ class AnnotationAdmin(admin.ModelAdmin):
     # readonly_fields = ('text', 'quote', 'extra_data', 'uri_link')
     readonly_fields = ('text', 'quote', 'uri_link')
 
+admin.site.register(Annotation, AnnotationAdmin)
 
 # custom model form to allow users to be edited on the group
 # edit form using the admin horizontal widget; based on
 # http://stackoverflow.com/questions/9879687/adding-a-manytomanywidget-to-the-reverse-of-a-manytomanyfield-in-the-django-admi
+#
+# NOTE: currently annotation groups are only enabled when per-object
+# permissions is turned on
 
-class AnnotationGroupForm(forms.ModelForm):
-    users = forms.ModelMultipleChoiceField(
-        User.objects.all(),
-        widget=admin.widgets.FilteredSelectMultiple('Users', False),
-        required=False
-    )
+if ANNOTATION_OBJECT_PERMISSIONS:
+    class AnnotationGroupForm(forms.ModelForm):
+        users = forms.ModelMultipleChoiceField(
+            User.objects.all(),
+            widget=admin.widgets.FilteredSelectMultiple('Users', False),
+            required=False
+        )
 
-    def __init__(self, *args, **kwargs):
-        super(AnnotationGroupForm, self).__init__(*args, **kwargs)
-        if self.instance.pk:
-            initial_users = self.instance.user_set.values_list('pk', flat=True)
-            self.initial['users'] = initial_users
+        def __init__(self, *args, **kwargs):
+            super(AnnotationGroupForm, self).__init__(*args, **kwargs)
+            if self.instance.pk:
+                initial_users = self.instance.user_set.values_list('pk', flat=True)
+                self.initial['users'] = initial_users
 
-    def save(self, *args, **kwargs):
-        kwargs['commit'] = True
-        return super(AnnotationGroupForm, self).save(*args, **kwargs)
+        def save(self, *args, **kwargs):
+            kwargs['commit'] = True
+            return super(AnnotationGroupForm, self).save(*args, **kwargs)
 
-    def save_m2m(self):
-        self.instance.user_set.clear()
-        self.instance.user_set.add(*self.cleaned_data['users'])
-
-
-class AnnotationGroupAdmin(admin.ModelAdmin):
-    list_display = ('name', 'num_members', 'created', 'updated')
-    date_hierarchy = 'created'
-    exclude = ('permissions',)
-    form = AnnotationGroupForm
-
-#  customize default group display to indicate annotation groups #
-
-# patch in a boolean property field to indicate annotation groups
-def is_annotationgroup(obj):
-    return hasattr(obj, 'annotationgroup')
-is_annotationgroup.boolean = True
-is_annotationgroup.short_description = 'Annotation group'
-
-Group.is_annotationgroup = is_annotationgroup
+        def save_m2m(self):
+            self.instance.user_set.clear()
+            self.instance.user_set.add(*self.cleaned_data['users'])
 
 
-class GroupAdmin(admin.ModelAdmin):
-    list_display = ('name', 'is_annotationgroup')
+    class AnnotationGroupAdmin(admin.ModelAdmin):
+        list_display = ('name', 'num_members', 'created', 'updated')
+        date_hierarchy = 'created'
+        exclude = ('permissions',)
+        form = AnnotationGroupForm
+
+    #  customize default group display to indicate annotation groups #
+
+    # patch in a boolean property field to indicate annotation groups
+    def is_annotationgroup(obj):
+        return hasattr(obj, 'annotationgroup')
+    is_annotationgroup.boolean = True
+    is_annotationgroup.short_description = 'Annotation group'
+
+    Group.is_annotationgroup = is_annotationgroup
 
 
-admin.site.register(Annotation, AnnotationAdmin)
-admin.site.register(AnnotationGroup, AnnotationGroupAdmin)
+    class GroupAdmin(admin.ModelAdmin):
+        list_display = ('name', 'is_annotationgroup')
 
 
-admin.site.unregister(Group)
-admin.site.register(Group, GroupAdmin)
+    admin.site.register(AnnotationGroup, AnnotationGroupAdmin)
+    admin.site.unregister(Group)
+    admin.site.register(Group, GroupAdmin)

--- a/annotator_store/models.py
+++ b/annotator_store/models.py
@@ -213,7 +213,8 @@ class BaseAnnotation(models.Model):
 
     def text_preview(self):
         'Short preview of annotation text content'
-        return self.text[:100] + ('...' if len(self.text) > 100 else '')
+        if self.text:
+            return self.text[:100] + ('...' if len(self.text) > 100 else '')
     text_preview.short_description = 'Text'
 
     def uri_link(self):

--- a/annotator_store/templates/annotator_store/snippets/annotator_init.html
+++ b/annotator_store/templates/annotator_store/snippets/annotator_init.html
@@ -156,9 +156,11 @@ $.ajaxSetup({
       //     volume_uri: '{{ volume_uri }}'
       //   },
       // })
+      {% comment %}
       {% if mode = 'full' %}
       .include(annotation_permissions.getModule);
       {% endif %}
+      {% endcomment %}
 
   app.start()
       .then(function () {

--- a/annotator_store/tests.py
+++ b/annotator_store/tests.py
@@ -8,7 +8,7 @@ except ImportError:
 import uuid
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Permission, AnonymousUser
 from django.core.urlresolvers import reverse, resolve
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -74,7 +74,7 @@ class AnnotationTestCase(TestCase):
 
     def setUp(self):
         # use mock to simulate django httprequest
-        self.mockrequest = Mock()
+        self.mockrequest = Mock(user=get_user_model().objects.get(username='testuser'))
         self.mockrequest.body = six.b(json.dumps(self.annotation_data))
 
     def test_create_from_request(self):
@@ -85,7 +85,9 @@ class AnnotationTestCase(TestCase):
         self.assert_('ranges' in note.extra_data)
         self.assertEqual(self.annotation_data['ranges'][0]['start'],
             note.extra_data['ranges'][0]['start'])
-        self.assert_('permissions' in note.extra_data)
+        # this behavior changes when permissions are enabled
+        if not ANNOTATION_OBJECT_PERMISSIONS:
+            self.assert_('permissions' in note.extra_data)
 
         # create from request with user specified
         user = get_user_model().objects.get(username='testuser')
@@ -173,7 +175,7 @@ if ANNOTATION_OBJECT_PERMISSIONS:
 
         def setUp(self):
             # use mock to simulate django httprequest
-            self.mockrequest = Mock()
+            self.mockrequest = Mock(user=get_user_model().objects.get(username='testuser'))
             self.mockrequest.body = six.b(json.dumps(self.annotation_data))
 
         def test_visible_to(self):

--- a/annotator_store/tests.py
+++ b/annotator_store/tests.py
@@ -6,6 +6,7 @@ except ImportError:
     # python 2.7
     from mock import Mock, patch
 import uuid
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse, resolve
 from django.test import TestCase
@@ -13,7 +14,15 @@ from django.test.utils import override_settings
 from guardian.shortcuts import remove_perm
 import six
 
-from .models import Annotation, AnnotationGroup
+from .models import Annotation, ANNOTATION_OBJECT_PERMISSIONS
+if ANNOTATION_OBJECT_PERMISSIONS:
+    # annotation group is only defined when permissions are enabled
+    from .models import AnnotationGroup
+
+
+# TODO: how to test functionality when per-object permissions are
+# turned off and/or guardian is not installed?
+# - could this be tested via travis-ci env settings?
 
 
 class AnnotationTestCase(TestCase):
@@ -76,36 +85,6 @@ class AnnotationTestCase(TestCase):
         note = Annotation.create_from_request(self.mockrequest)
         self.assertEqual(user, note.user)
 
-    def test_update_from_request(self):
-        # create test note to update
-        note = Annotation(text="Here's the thing", quote="really",
-            extra_data=json.dumps({'sample data': 'foobar'}))
-        note.save()
-
-        # permissions check requires a real user
-        user = get_user_model().objects.get(username='testuser')
-        self.mockrequest.user = user
-
-        with patch.object(note, 'db_permissions') as mock_db_perms:
-            note.update_from_request(self.mockrequest)
-            self.assertEqual(self.annotation_data['text'], note.text)
-            self.assertEqual(self.annotation_data['quote'], note.quote)
-            self.assertEqual(self.annotation_data['uri'], note.uri)
-            self.assert_('ranges' in note.extra_data)
-            self.assertEqual(self.annotation_data['ranges'][0]['start'],
-                note.extra_data['ranges'][0]['start'])
-            self.assert_('permissions' not in note.extra_data)
-            # existing extra data should no longer present
-            self.assert_('sample data' not in note.extra_data)
-
-            # testuser does not have admin on this annotation;
-            # permissions should not be updated
-            mock_db_perms.assert_not_called()
-
-            # give user admin permission and update again
-            note.assign_permission('admin_annotation', user)
-            note.update_from_request(self.mockrequest)
-            mock_db_perms.assert_called_with(self.annotation_data['permissions'])
 
     def test_info(self):
         note = Annotation.create_from_request(self.mockrequest)
@@ -128,21 +107,6 @@ class AnnotationTestCase(TestCase):
 
         # TODO assert includes permissions dict when appropriate
 
-    def test_visible_to(self):
-        # delete fixture annotations and test only those created here
-        Annotation.objects.all().delete()
-
-        testuser = get_user_model().objects.get(username='testuser')
-        testadmin = get_user_model().objects.get(username='testsuper')
-
-        Annotation.objects.create(user=testuser, text='foo')
-        Annotation.objects.create(user=testuser, text='bar')
-        Annotation.objects.create(user=testuser, text='baz')
-        Annotation.objects.create(user=testadmin, text='qux')
-
-        self.assertEqual(3, Annotation.objects.visible_to(testuser).count())
-        self.assertEqual(4, Annotation.objects.visible_to(testadmin).count())
-
     def test_last_created_time(self):
         # test custom queryset methods
         Annotation.objects.all().delete()  # delete fixture annotations
@@ -162,7 +126,6 @@ class AnnotationTestCase(TestCase):
         self.assertEqual(note.updated,
                          Annotation.objects.all().last_updated_time())
 
-
     def test_related_pages(self):
         note = Annotation.create_from_request(self.mockrequest)
         self.assertEqual(len(self.annotation_data['related_pages']),
@@ -176,147 +139,209 @@ class AnnotationTestCase(TestCase):
         note = Annotation()
         self.assertEqual(None, note.related_pages)
 
-    def test_user_permissions(self):
-        # annotation user/owner automatically gets permissions
-        user = get_user_model().objects.get(username='testuser')
-        note = Annotation.create_from_request(self.mockrequest)
-        note.user = user
-        note.save()
 
-        user_perms = note.user_permissions()
-        self.assertEqual(4, user_perms.count())
-        self.assert_(user_perms.filter(user=user,
-                                       permission__codename='view_annotation')
-                               .exists())
-        self.assert_(user_perms.filter(user=user,
-                                       permission__codename='change_annotation')
-                               .exists())
-        self.assert_(user_perms.filter(user=user,
-                                       permission__codename='delete_annotation')
-                               .exists())
-        self.assert_(user_perms.filter(user=user,
-                                       permission__codename='admin_annotation')
-                               .exists())
 
-        note.save()
-        # saving again shouldn't duplicate the permissions
-        self.assertEqual(4, note.user_permissions().count())
 
-    def test_db_permissions(self):
-        note = Annotation.create_from_request(self.mockrequest)
-        note.save()
-        # get some users and groups to work with
-        user = get_user_model().objects.get(username='testuser')
-        group1 = AnnotationGroup.objects.create(name='foo')
-        group2 = AnnotationGroup.objects.create(name='foobar')
+if ANNOTATION_OBJECT_PERMISSIONS:
 
-        note.db_permissions({
-            'read': [user.username, group1.annotation_id,
-                     group2.annotation_id],
-            'update': [user.username, group1.annotation_id],
-            'delete': [user.username]
-        })
+    class AnnotationPermissionsTestCase(TestCase):
+        fixtures = ['test_annotation_data.json']
 
-        # inspect the db permissions created
+        annotation_data = AnnotationTestCase.annotation_data
 
-        # should be two total user permissions, one to view and one to change
-        user_perms = note.user_permissions()
-        self.assertEqual(3, user_perms.count())
-        self.assert_(user_perms.filter(user=user,
-                                       permission__codename='view_annotation')
-                               .exists())
-        self.assert_(user_perms.filter(user=user,
-                                       permission__codename='change_annotation')
-                               .exists())
-        self.assert_(user_perms.filter(user=user,
-                                       permission__codename='delete_annotation')
-                               .exists())
+        def setUp(self):
+            # use mock to simulate django httprequest
+            self.mockrequest = Mock()
+            self.mockrequest.body = six.b(json.dumps(self.annotation_data))
 
-        # should be three total group permissions
-        group_perms = note.group_permissions()
-        self.assertEqual(3, group_perms.count())
-        self.assert_(group_perms.filter(group=group1,
-                                        permission__codename='view_annotation')
-                                .exists())
-        self.assert_(group_perms.filter(group=group1,
-                                        permission__codename='change_annotation')
-                                .exists())
-        self.assert_(group_perms.filter(group=group2,
-                                        permission__codename='view_annotation')
-                                .exists())
+        def test_visible_to(self):
+            # delete fixture annotations and test only those created here
+            Annotation.objects.all().delete()
 
-        # updating the permissions for the same note should
-        # remove permissions that no longer apply
-        note.db_permissions({
-            'read': [user.username, group1.annotation_id],
-            'update': [user.username],
-            'delete': []
-        })
+            testuser = get_user_model().objects.get(username='testuser')
+            testadmin = get_user_model().objects.get(username='testsuper')
 
-        # counts should reflect the changes
-        user_perms = note.user_permissions()
-        self.assertEqual(2, user_perms.count())
-        group_perms = note.group_permissions()
-        self.assertEqual(1, group_perms.count())
+            Annotation.objects.create(user=testuser, text='foo')
+            Annotation.objects.create(user=testuser, text='bar')
+            Annotation.objects.create(user=testuser, text='baz')
+            Annotation.objects.create(user=testadmin, text='qux')
 
-        # permissions created before should be gone
-        self.assertFalse(user_perms.filter(user=user,
+            self.assertEqual(3, Annotation.objects.visible_to(testuser).count())
+            self.assertEqual(4, Annotation.objects.visible_to(testadmin).count())
+
+        def test_update_from_request(self):
+            # create test note to update
+            note = Annotation(text="Here's the thing", quote="really",
+                extra_data=json.dumps({'sample data': 'foobar'}))
+            note.save()
+
+            # permissions check requires a real user
+            user = get_user_model().objects.get(username='testuser')
+            self.mockrequest.user = user
+
+            with patch.object(note, 'db_permissions') as mock_db_perms:
+                note.update_from_request(self.mockrequest)
+                self.assertEqual(self.annotation_data['text'], note.text)
+                self.assertEqual(self.annotation_data['quote'], note.quote)
+                self.assertEqual(self.annotation_data['uri'], note.uri)
+                self.assert_('ranges' in note.extra_data)
+                self.assertEqual(self.annotation_data['ranges'][0]['start'],
+                    note.extra_data['ranges'][0]['start'])
+                self.assert_('permissions' not in note.extra_data)
+                # existing extra data should no longer present
+                self.assert_('sample data' not in note.extra_data)
+
+                # testuser does not have admin on this annotation;
+                # permissions should not be updated
+                mock_db_perms.assert_not_called()
+
+                # give user admin permission and update again
+                note.assign_permission('admin_annotation', user)
+                note.update_from_request(self.mockrequest)
+                mock_db_perms.assert_called_with(self.annotation_data['permissions'])
+
+        def test_user_permissions(self):
+            # annotation user/owner automatically gets permissions
+            user = get_user_model().objects.get(username='testuser')
+            note = Annotation.create_from_request(self.mockrequest)
+            note.user = user
+            note.save()
+
+            user_perms = note.user_permissions()
+            self.assertEqual(4, user_perms.count())
+            self.assert_(user_perms.filter(user=user,
+                                           permission__codename='view_annotation')
+                                   .exists())
+            self.assert_(user_perms.filter(user=user,
+                                           permission__codename='change_annotation')
+                                   .exists())
+            self.assert_(user_perms.filter(user=user,
                                            permission__codename='delete_annotation')
                                    .exists())
-        self.assertFalse(group_perms.filter(group=group1,
+            self.assert_(user_perms.filter(user=user,
+                                           permission__codename='admin_annotation')
+                                   .exists())
+
+            note.save()
+            # saving again shouldn't duplicate the permissions
+            self.assertEqual(4, note.user_permissions().count())
+
+        def test_db_permissions(self):
+            note = Annotation.create_from_request(self.mockrequest)
+            note.save()
+            # get some users and groups to work with
+            user = get_user_model().objects.get(username='testuser')
+            group1 = AnnotationGroup.objects.create(name='foo')
+            group2 = AnnotationGroup.objects.create(name='foobar')
+
+            note.db_permissions({
+                'read': [user.username, group1.annotation_id,
+                         group2.annotation_id],
+                'update': [user.username, group1.annotation_id],
+                'delete': [user.username]
+            })
+
+            # inspect the db permissions created
+
+            # should be two total user permissions, one to view and one to change
+            user_perms = note.user_permissions()
+            self.assertEqual(3, user_perms.count())
+            self.assert_(user_perms.filter(user=user,
+                                           permission__codename='view_annotation')
+                                   .exists())
+            self.assert_(user_perms.filter(user=user,
+                                           permission__codename='change_annotation')
+                                   .exists())
+            self.assert_(user_perms.filter(user=user,
+                                           permission__codename='delete_annotation')
+                                   .exists())
+
+            # should be three total group permissions
+            group_perms = note.group_permissions()
+            self.assertEqual(3, group_perms.count())
+            self.assert_(group_perms.filter(group=group1,
+                                            permission__codename='view_annotation')
+                                    .exists())
+            self.assert_(group_perms.filter(group=group1,
                                             permission__codename='change_annotation')
                                     .exists())
-        self.assertFalse(group_perms.filter(group=group2,
+            self.assert_(group_perms.filter(group=group2,
                                             permission__codename='view_annotation')
                                     .exists())
 
-        # invalid group/user should not error
-        note.db_permissions({
-            'read': ['bogus', 'group:666', 'group:foo'],
-            'update': ['group:__world__'],
-            'delete': []
-        })
+            # updating the permissions for the same note should
+            # remove permissions that no longer apply
+            note.db_permissions({
+                'read': [user.username, group1.annotation_id],
+                'update': [user.username],
+                'delete': []
+            })
 
-        self.assertEqual(0, note.user_permissions().count())
-        self.assertEqual(0, note.group_permissions().count())
+            # counts should reflect the changes
+            user_perms = note.user_permissions()
+            self.assertEqual(2, user_perms.count())
+            group_perms = note.group_permissions()
+            self.assertEqual(1, group_perms.count())
+
+            # permissions created before should be gone
+            self.assertFalse(user_perms.filter(user=user,
+                                               permission__codename='delete_annotation')
+                                       .exists())
+            self.assertFalse(group_perms.filter(group=group1,
+                                                permission__codename='change_annotation')
+                                        .exists())
+            self.assertFalse(group_perms.filter(group=group2,
+                                                permission__codename='view_annotation')
+                                        .exists())
+
+            # invalid group/user should not error
+            note.db_permissions({
+                'read': ['bogus', 'group:666', 'group:foo'],
+                'update': ['group:__world__'],
+                'delete': []
+            })
+
+            self.assertEqual(0, note.user_permissions().count())
+            self.assertEqual(0, note.group_permissions().count())
 
 
-    def test_permissions_dict(self):
-        note = Annotation.create_from_request(self.mockrequest)
-        note.save()
-        # get some users and groups to work with
-        user = get_user_model().objects.get(username='testuser')
-        group1 = AnnotationGroup.objects.create(name='foo')
-        group2 = AnnotationGroup.objects.create(name='foobar')
+        def test_permissions_dict(self):
+            note = Annotation.create_from_request(self.mockrequest)
+            note.save()
+            # get some users and groups to work with
+            user = get_user_model().objects.get(username='testuser')
+            group1 = AnnotationGroup.objects.create(name='foo')
+            group2 = AnnotationGroup.objects.create(name='foobar')
 
-        perms = {
-            'read': [user.username, group1.annotation_id,
-                     group2.annotation_id],
-            'update': [user.username, group1.annotation_id],
-            'delete': [user.username],
-            'admin': []
-        }
-        # test round-trip: convert to db permissions and then back
-        note.db_permissions(perms)
-        self.assertEqual(perms, note.permissions_dict())
+            perms = {
+                'read': [user.username, group1.annotation_id,
+                         group2.annotation_id],
+                'update': [user.username, group1.annotation_id],
+                'delete': [user.username],
+                'admin': []
+            }
+            # test round-trip: convert to db permissions and then back
+            note.db_permissions(perms)
+            self.assertEqual(perms, note.permissions_dict())
 
-        perms = {
-            'read': [user.username, group1.annotation_id],
-            'update': [user.username],
-            'delete': [],
-            'admin': []
-        }
-        note.db_permissions(perms)
-        self.assertEqual(perms, note.permissions_dict())
+            perms = {
+                'read': [user.username, group1.annotation_id],
+                'update': [user.username],
+                'delete': [],
+                'admin': []
+            }
+            note.db_permissions(perms)
+            self.assertEqual(perms, note.permissions_dict())
 
-        perms = {
-            'read': [],
-            'update': [],
-            'delete': [],
-            'admin': []
-        }
-        note.db_permissions(perms)
-        self.assertEqual(perms, note.permissions_dict())
+            perms = {
+                'read': [],
+                'update': [],
+                'delete': [],
+                'admin': []
+            }
+            note.db_permissions(perms)
+            self.assertEqual(perms, note.permissions_dict())
+
 
 
 @override_settings(AUTHENTICATION_BACKENDS=('django.contrib.auth.backends.ModelBackend',))

--- a/annotator_store/tests.py
+++ b/annotator_store/tests.py
@@ -30,6 +30,9 @@ if ANNOTATION_OBJECT_PERMISSIONS:
 # - could this be tested via travis-ci env settings?
 
 
+
+
+
 class AnnotationTestCase(TestCase):
     fixtures = ['test_annotation_data.json']
 
@@ -90,7 +93,6 @@ class AnnotationTestCase(TestCase):
         note = Annotation.create_from_request(self.mockrequest)
         self.assertEqual(user, note.user)
 
-
     def test_info(self):
         note = Annotation.create_from_request(self.mockrequest)
         note.save()  # save so created/updated will get set
@@ -144,7 +146,22 @@ class AnnotationTestCase(TestCase):
         note = Annotation()
         self.assertEqual(None, note.related_pages)
 
+    def test_handle_extra_data(self):
+        # test handle extra data method to check it is called appropriately
+        def test_handler(obj, data, request):
+            obj.quote += ' mischief managed!'
+            return {'foo': 'bar'}
 
+        with patch.object(Annotation, 'handle_extra_data', new=test_handler):
+            # should be called when creating a new object
+            note = Annotation.create_from_request(self.mockrequest)
+            assert note.quote.endswith('mischief managed!')
+            assert note.extra_data == {'foo': 'bar'}
+
+            # should be called when updating objects
+            note.update_from_request(self.mockrequest)
+            assert note.quote.endswith('mischief managed!')
+            assert note.extra_data == {'foo': 'bar'}
 
 
 if ANNOTATION_OBJECT_PERMISSIONS:

--- a/annotator_store/views.py
+++ b/annotator_store/views.py
@@ -8,7 +8,7 @@ from django.views.generic import View
 from eulcommon.djangoextras.auth import login_required_with_ajax
 from eulcommon.djangoextras.http.responses import HttpResponseSeeOtherRedirect
 
-from .models import get_annotation_model
+from .models import get_annotation_model, ANNOTATION_OBJECT_PERMISSIONS
 from .utils import absolutize_url
 
 

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -40,7 +40,7 @@ ROOT_URLCONF = 'annotator_store.test_urls'
 # ANNOTATOR_ANNOTATION_MODEL = "annotator_store.Annotation"
 
 # enable or disable permissions testing based on true/false environment variable
-ANNOTATION_OBJECT_PERMISSIONS = os.environ['PERMISSIONS']
+ANNOTATION_OBJECT_PERMISSIONS = os.environ.get('PERMISSIONS', False)
 
 if ANNOTATION_OBJECT_PERMISSIONS:
     print('Enabling per-object permissions and django-guardian')

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -40,7 +40,7 @@ ROOT_URLCONF = 'annotator_store.test_urls'
 # ANNOTATOR_ANNOTATION_MODEL = "annotator_store.Annotation"
 
 # enable or disable permissions testing based on true/false environment variable
-ANNOTATION_OBJECT_PERMISSIONS = os.environ.get('PERMISSIONS', False)
+ANNOTATION_OBJECT_PERMISSIONS = (os.environ.get('PERMISSIONS', '') == 'true')
 
 if ANNOTATION_OBJECT_PERMISSIONS:
     print('Enabling per-object permissions and django-guardian')

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -1,4 +1,6 @@
 # minimal django settings required to run tests
+import os
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
@@ -6,19 +8,17 @@ DATABASES = {
     }
 }
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
-    'guardian',
     'annotator_store',
-)
+]
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',   # default
-    # 'guardian.backends.ObjectPermissionBackend',
-)
+]
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
@@ -27,7 +27,6 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
@@ -37,5 +36,17 @@ SITE_ID = 1
 
 ROOT_URLCONF = 'annotator_store.test_urls'
 
-# SECRET_KEY = ''
+# default annotation model
+# ANNOTATOR_ANNOTATION_MODEL = "annotator_store.Annotation"
 
+# enable or disable permissions testing based on true/false environment variable
+ANNOTATION_OBJECT_PERMISSIONS = os.environ['PERMISSIONS']
+
+if ANNOTATION_OBJECT_PERMISSIONS:
+    print('Enabling per-object permissions and django-guardian')
+    INSTALLED_APPS.append('guardian')
+    AUTHENTICATION_BACKENDS.append('guardian.backends.ObjectPermissionBackend')
+else:
+    print('Testing with normal django permissions (no django-guardian)')
+
+# SECRET_KEY = ''

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     url='https://github.com/Princeton-CDH/django-annotator-store',
     install_requires=[
         'django>1.8',
-        'django-guardian',
         'pytz',
         'jsonfield',
         'eulcommon',
@@ -36,6 +35,7 @@ setup(
     extras_require={
         'test': TEST_REQUIREMENTS,
         'docs': ['sphinx'],
+        'permissions': ['django-guardian',]
     },
     author='CDH @ Princeton',
     author_email='digitalhumanities@princeton.edu',


### PR DESCRIPTION
@bwhicks I think I've got this working properly and am fairly satisfied by the way I'm running the tests now, but would appreciate if you could look it over and see if what I've done makes sense.

I did try switching to the `user.has_perm` check as we discussed, but I wasn't getting the response I expected, so I left the code as it is.

Glancing at the changes, I realize that I haven't really documented the annotation groups or the fact that you need to include a permissions annotator.js plugin (which is probably still only in the readux codebase and not included here) - but I think that might be reasonable for now.  Those aspects probably need to be refined and revisited before they're really ready for use, which don't need or have time to do now. I think we'll just have to make it clear that per-object user and group permissions aren't fully supported yet.