### PR TITLE
Check if guardian is installed only if per-object permission are enabled

### DIFF
--- a/annotator_store/models.py
+++ b/annotator_store/models.py
@@ -10,24 +10,23 @@ from django.core.urlresolvers import reverse
 from django.contrib.auth.models import Group, User
 from django.utils.html import format_html
 from jsonfield import JSONField
-try:
+
+# get system logger for notifying test errors/warnings
+logger = logging.getLogger(__name__)
+# get per-object permission flag
+ANNOTATION_OBJECT_PERMISSIONS = getattr(settings, 'ANNOTATION_OBJECT_PERMISSIONS', False)
+# guardian support is disabled by default
+guardian = False
+# only import guardian when object permissions are enabled
+if ANNOTATION_OBJECT_PERMISSIONS:
     import guardian
     from guardian.shortcuts import assign_perm, get_objects_for_user, \
         get_objects_for_group, get_perms_for_model, get_perms
     from guardian.models import UserObjectPermission, GroupObjectPermission
-except ImportError:
-    guardian = None
 import six
-
-
-logger = logging.getLogger(__name__)
-
 
 ANNOTATION_MODEL_NAME = getattr(settings, 'ANNOTATOR_ANNOTATION_MODEL',
     "annotator_store.Annotation")
-
-ANNOTATION_OBJECT_PERMISSIONS = getattr(settings, 'ANNOTATION_OBJECT_PERMISSIONS',
-    False)
 
 
 class AnnotationQuerySet(models.QuerySet):

--- a/annotator_store/tests.py
+++ b/annotator_store/tests.py
@@ -20,9 +20,10 @@ from django.core.urlresolvers import reverse, resolve
 from django.http import HttpResponse, HttpRequest
 from django.test import TestCase
 from django.test.utils import override_settings
-try:
+from .models import ANNOTATION_OBJECT_PERMISSIONS, guardian
+if ANNOTATION_OBJECT_PERMISSIONS and guardian:
     from guardian.shortcuts import remove_perm
-except ImportError:
+else:
     remove_perm = None
 import pytest
 import six

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=README,
     url='https://github.com/Princeton-CDH/django-annotator-store',
     install_requires=[
-        'django>1.8',
+        'django>=1.8',
         'pytz',
         'jsonfield',
         'eulcommon',


### PR DESCRIPTION
This fixes an error on system where guardian is installed but per object permission are disabled.