### PR TITLE
Correct support for django 1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=README,
     url='https://github.com/Princeton-CDH/django-annotator-store',
     install_requires=[
-        'django>1.8',
+        'django>=1.8',
         'pytz',
         'jsonfield',
         'eulcommon',


### PR DESCRIPTION
Travis is installing Django 2.0 instead of django 1.8.
Travis do that because is required a version of Django newer than 1.8. In setup.py
```
install_requires=[
        'django>1.8',
        'pytz',
        'jsonfield',
        'eulcommon',
        'six',
    ],
```
But then travis environment variables are configured to execute test also for version 1.8.
Travis doesn't install it for setup.py constraint and it proceed to install the newest version of django.
This was 1.11 some months ago, so tests for 1.8 were executed with versions 1.11. But everything worked because 1.11 is backward compatible.
Now the new version 2.0 is not compatible with python 2.7 and is not backward compatible. This is the reason of builds failing now.